### PR TITLE
feat: update histogramming

### DIFF
--- a/src/egamma_tnp/triggers/basedoubleelectrontrigger.py
+++ b/src/egamma_tnp/triggers/basedoubleelectrontrigger.py
@@ -76,34 +76,16 @@ class BaseDoubleElectronTrigger:
             array_dict: dict
             A dictionary with keys "leg1" and/or "leg2" depending on the leg parameter.
             The value for each key is a tuple of the form (arrays, report) if `allow_read_errors_with_report` is True, otherwise just arrays.
-            arrays : dict of tuples of the same form as fileset where for each dataset the following arrays are present:
-            The fileset where for each dataset the following arrays are added:
-                pt_pass1: awkward.Array or dask_awkward.Array
-                    The Pt array of the passing probes when the firsts electrons are the tags.
-                pt_pass2: awkward.Array or dask_awkward.Array
-                    The Pt array of the passing probes when the seconds electrons are the tags.
-                pt_all1: awkward.Array or dask_awkward.Array
-                    The Pt array of all probes when the firsts electrons are the tags.
-                pt_all2: awkward.Array or dask_awkward.Array
-                    The Pt array of all probes when the seconds electrons are the tags.
-                eta_pass1: awkward.Array or dask_awkward.Array
-                    The Eta array of the passing probes when the firsts electrons are the tags.
-                eta_pass2: awkward.Array or dask_awkward.Array
-                    The Eta array of the passing probes when the seconds electrons are the tags.
-                eta_all1: awkward.Array or dask_awkward.Array
-                    The Eta array of all probes when the firsts electrons are the tags.
-                eta_all2: awkward.Array or dask_awkward.Array
-                    The Eta array of all probes when the seconds electrons are the tags.
-                phi_pass1: awkward.Array or dask_awkward.Array
-                    The Phi array of the passing probes when the firsts electrons are the tags.
-                phi_pass2: awkward.Array or dask_awkward.Array
-                    The Phi array of the passing probes when the seconds electrons are the tags.
-                phi_all1: awkward.Array or dask_awkward.Array
-                    The Phi array of all probes when the firsts electrons are the tags.
-                phi_all2: awkward.Array or dask_awkward.Array
-                    The Phi array of all probes when the seconds electrons are the tags.
-                report: dict of awkward arrays of the same form as fileset.
-                    For each dataset an awkward array that contains information about the file access is present.
+            arrays :a tuple of dask awkward zip items of the form (passing_probes, all_probes).
+                Each of the zip items has the following fields:
+                    pt: dask_awkward.Array
+                        The Pt array of the probes.
+                    eta: dask_awkward.array
+                        The Eta array of the probes.
+                    phi: dask_awkward.array
+                        The Phi array of the probes.
+            report: dict of awkward arrays of the same form as fileset.
+                For each dataset an awkward array that contains information about the file access is present.
         """
         if uproot_options is None:
             uproot_options = {}

--- a/src/egamma_tnp/triggers/basesingleelectrontrigger.py
+++ b/src/egamma_tnp/triggers/basesingleelectrontrigger.py
@@ -65,35 +65,16 @@ class BaseSingleElectronTrigger:
 
         Returns
         -------
-            A tuple of the form (arrays, report) if `allow_read_errors_with_report` is True, otherwise just arrays.
-            arrays : dict of tuples of the same form as fileset where for each dataset the following arrays are present:
-            The fileset where for each dataset the following arrays are added:
-                pt_pass1: awkward.Array or dask_awkward.Array
-                    The Pt array of the passing probes when the firsts electrons are the tags.
-                pt_pass2: awkward.Array or dask_awkward.Array
-                    The Pt array of the passing probes when the seconds electrons are the tags.
-                pt_all1: awkward.Array or dask_awkward.Array
-                    The Pt array of all probes when the firsts electrons are the tags.
-                pt_all2: awkward.Array or dask_awkward.Array
-                    The Pt array of all probes when the seconds electrons are the tags.
-                eta_pass1: awkward.Array or dask_awkward.Array
-                    The Eta array of the passing probes when the firsts electrons are the tags.
-                eta_pass2: awkward.Array or dask_awkward.Array
-                    The Eta array of the passing probes when the seconds electrons are the tags.
-                eta_all1: awkward.Array or dask_awkward.Array
-                    The Eta array of all probes when the firsts electrons are the tags.
-                eta_all2: awkward.Array or dask_awkward.Array
-                    The Eta array of all probes when the seconds electrons are the tags.
-                phi_pass1: awkward.Array or dask_awkward.Array
-                    The Phi array of the passing probes when the firsts electrons are the tags.
-                phi_pass2: awkward.Array or dask_awkward.Array
-                    The Phi array of the passing probes when the seconds electrons are the tags.
-                phi_all1: awkward.Array or dask_awkward.Array
-                    The Phi array of all probes when the firsts electrons are the tags.
-                phi_all2: awkward.Array or dask_awkward.Array
-                    The Phi array of all probes when the seconds electrons are the tags.
-                report: dict of awkward arrays of the same form as fileset.
-                    For each dataset an awkward array that contains information about the file access is present.
+            arrays :a tuple of dask awkward zip items of the form (passing_probes, all_probes).
+                Each of the zip items has the following fields:
+                    pt: dask_awkward.Array
+                        The Pt array of the probes.
+                    eta: dask_awkward.array
+                        The Eta array of the probes.
+                    phi: dask_awkward.array
+                        The Phi array of the probes.
+            report: dict of awkward arrays of the same form as fileset.
+                For each dataset an awkward array that contains information about the file access is present.
         """
         if uproot_options is None:
             uproot_options = {}
@@ -190,7 +171,6 @@ class BaseSingleElectronTrigger:
                 These are the histograms of the passing and all probes respectively.
             report: dict of awkward arrays of the same form as fileset.
                 For each dataset an awkward array that contains information about the file access is present.
-
         """
         if uproot_options is None:
             uproot_options = {}

--- a/src/egamma_tnp/triggers/basesingleelectrontrigger.py
+++ b/src/egamma_tnp/triggers/basesingleelectrontrigger.py
@@ -1,7 +1,6 @@
 import os
 from functools import partial
 
-import dask_awkward as dak
 from coffea.dataset_tools import apply_to_fileset
 from coffea.nanoevents import NanoAODSchema
 
@@ -108,7 +107,7 @@ class BaseSingleElectronTrigger:
             extra_filter=self._extra_filter,
             extra_filter_args=self._extra_filter_args,
         )
-        data_manipulation = partial(self._get_tnp_arrays_core, perform_tnp=perform_tnp)
+        data_manipulation = perform_tnp
 
         to_compute = apply_to_fileset(
             data_manipulation=data_manipulation,
@@ -193,18 +192,6 @@ class BaseSingleElectronTrigger:
                 For each dataset an awkward array that contains information about the file access is present.
 
         """
-        if plateau_cut is None:
-            plateau_cut = 0
-        if eta_regions_pt is None:
-            eta_regions_pt = {
-                "barrel": [0.0, 1.4442],
-                "endcap": [1.566, 2.5],
-            }
-        if eta_regions_eta is None:
-            eta_regions_eta = {"entire": [0.0, 2.5]}
-        if eta_regions_phi is None:
-            eta_regions_phi = {"entire": [0.0, 2.5]}
-
         if uproot_options is None:
             uproot_options = {}
 
@@ -218,7 +205,7 @@ class BaseSingleElectronTrigger:
             extra_filter_args=self._extra_filter_args,
         )
         data_manipulation = partial(
-            self._get_tnp_histograms_core,
+            self._make_tnp_histograms,
             perform_tnp=perform_tnp,
             plateau_cut=plateau_cut,
             eta_regions_pt=eta_regions_pt,
@@ -249,40 +236,7 @@ class BaseSingleElectronTrigger:
 
         return to_compute
 
-    def _get_tnp_arrays_core(self, events, perform_tnp):
-        p1, a1, p2, a2 = perform_tnp(events)
-
-        pt_pass1 = dak.flatten(p1.pt)
-        pt_pass2 = dak.flatten(p2.pt)
-        pt_all1 = dak.flatten(a1.pt)
-        pt_all2 = dak.flatten(a2.pt)
-
-        eta_pass1 = dak.flatten(p1.eta)
-        eta_pass2 = dak.flatten(p2.eta)
-        eta_all1 = dak.flatten(a1.eta)
-        eta_all2 = dak.flatten(a2.eta)
-
-        phi_pass1 = dak.flatten(p1.phi)
-        phi_pass2 = dak.flatten(p2.phi)
-        phi_all1 = dak.flatten(a1.phi)
-        phi_all2 = dak.flatten(a2.phi)
-
-        return (
-            pt_pass1,
-            pt_pass2,
-            pt_all1,
-            pt_all2,
-            eta_pass1,
-            eta_pass2,
-            eta_all1,
-            eta_all2,
-            phi_pass1,
-            phi_pass2,
-            phi_all1,
-            phi_all2,
-        )
-
-    def _get_tnp_histograms_core(
+    def _make_tnp_histograms(
         self,
         events,
         perform_tnp,
@@ -291,117 +245,14 @@ class BaseSingleElectronTrigger:
         eta_regions_eta,
         eta_regions_phi,
     ):
-        import hist
-        from hist.dask import Hist
+        from egamma_tnp.utils import fill_tnp_histograms
 
-        import egamma_tnp
-
-        ptbins = egamma_tnp.config.get("ptbins")
-        etabins = egamma_tnp.config.get("etabins")
-        phibins = egamma_tnp.config.get("phibins")
-
-        arrays = self._get_tnp_arrays_core(events, perform_tnp)
-        (
-            pt_pass1,
-            pt_pass2,
-            pt_all1,
-            pt_all2,
-            eta_pass1,
-            eta_pass2,
-            eta_all1,
-            eta_all2,
-            phi_pass1,
-            phi_pass2,
-            phi_all1,
-            phi_all2,
-        ) = arrays
-
-        histograms = {}
-        histograms["pt"] = {}
-        histograms["eta"] = {}
-        histograms["phi"] = {}
-
-        plateau_mask_pass1 = pt_pass1 > plateau_cut
-        plateau_mask_pass2 = pt_pass2 > plateau_cut
-        plateau_mask_all1 = pt_all1 > plateau_cut
-        plateau_mask_all2 = pt_all2 > plateau_cut
-
-        for name_pt, region_pt in eta_regions_pt.items():
-            eta_mask_pt_pass1 = (abs(eta_pass1) > region_pt[0]) & (
-                abs(eta_pass1) < region_pt[1]
-            )
-            eta_mask_pt_pass2 = (abs(eta_pass2) > region_pt[0]) & (
-                abs(eta_pass2) < region_pt[1]
-            )
-            eta_mask_pt_all1 = (abs(eta_all1) > region_pt[0]) & (
-                abs(eta_all1) < region_pt[1]
-            )
-            eta_mask_pt_all2 = (abs(eta_all2) > region_pt[0]) & (
-                abs(eta_all2) < region_pt[1]
-            )
-            hpt_pass = Hist(
-                hist.axis.Variable(ptbins, name=f"hpt_{name_pt}", label="Pt [GeV]")
-            )
-            hpt_all = Hist(
-                hist.axis.Variable(ptbins, name=f"hpt_{name_pt}", label="Pt [GeV]")
-            )
-            hpt_pass.fill(pt_pass1[eta_mask_pt_pass1])
-            hpt_pass.fill(pt_pass2[eta_mask_pt_pass2])
-            hpt_all.fill(pt_all1[eta_mask_pt_all1])
-            hpt_all.fill(pt_all2[eta_mask_pt_all2])
-
-            histograms["pt"][name_pt] = {"passing": hpt_pass, "all": hpt_all}
-
-        for name_eta, region_eta in eta_regions_eta.items():
-            eta_mask_eta_pass1 = (abs(eta_pass1) > region_eta[0]) & (
-                abs(eta_pass1) < region_eta[1]
-            )
-            eta_mask_eta_pass2 = (abs(eta_pass2) > region_eta[0]) & (
-                abs(eta_pass2) < region_eta[1]
-            )
-            eta_mask_eta_all1 = (abs(eta_all1) > region_eta[0]) & (
-                abs(eta_all1) < region_eta[1]
-            )
-            eta_mask_eta_all2 = (abs(eta_all2) > region_eta[0]) & (
-                abs(eta_all2) < region_eta[1]
-            )
-            heta_pass = Hist(
-                hist.axis.Variable(etabins, name=f"heta_{name_eta}", label="eta")
-            )
-            heta_all = Hist(
-                hist.axis.Variable(etabins, name=f"heta_{name_eta}", label="eta")
-            )
-            heta_pass.fill(eta_pass1[plateau_mask_pass1 & eta_mask_eta_pass1])
-            heta_pass.fill(eta_pass2[plateau_mask_pass2 & eta_mask_eta_pass2])
-            heta_all.fill(eta_all1[plateau_mask_all1 & eta_mask_eta_all1])
-            heta_all.fill(eta_all2[plateau_mask_all2 & eta_mask_eta_all2])
-
-            histograms["eta"][name_eta] = {"passing": heta_pass, "all": heta_all}
-
-        for name_phi, region_phi in eta_regions_phi.items():
-            eta_mask_phi_pass1 = (abs(eta_pass1) > region_phi[0]) & (
-                abs(eta_pass1) < region_phi[1]
-            )
-            eta_mask_phi_pass2 = (abs(eta_pass2) > region_phi[0]) & (
-                abs(eta_pass2) < region_phi[1]
-            )
-            eta_mask_phi_all1 = (abs(eta_all1) > region_phi[0]) & (
-                abs(eta_all1) < region_phi[1]
-            )
-            eta_mask_phi_all2 = (abs(eta_all2) > region_phi[0]) & (
-                abs(eta_all2) < region_phi[1]
-            )
-            hphi_pass = Hist(
-                hist.axis.Variable(phibins, name=f"hphi_{name_phi}", label="phi")
-            )
-            hphi_all = Hist(
-                hist.axis.Variable(phibins, name=f"hphi_{name_phi}", label="phi")
-            )
-            hphi_pass.fill(phi_pass1[plateau_mask_pass1 & eta_mask_phi_pass1])
-            hphi_pass.fill(phi_pass2[plateau_mask_pass2 & eta_mask_phi_pass2])
-            hphi_all.fill(phi_all1[plateau_mask_all1 & eta_mask_phi_all1])
-            hphi_all.fill(phi_all2[plateau_mask_all2 & eta_mask_phi_all2])
-
-            histograms["phi"][name_phi] = {"passing": hphi_pass, "all": hphi_all}
-
-        return histograms
+        passing_probes, all_probes = perform_tnp(events)
+        return fill_tnp_histograms(
+            passing_probes,
+            all_probes,
+            plateau_cut=plateau_cut,
+            eta_regions_pt=eta_regions_pt,
+            eta_regions_eta=eta_regions_eta,
+            eta_regions_phi=eta_regions_phi,
+        )

--- a/src/egamma_tnp/triggers/doubleelept_caloidl_mw.py
+++ b/src/egamma_tnp/triggers/doubleelept_caloidl_mw.py
@@ -60,7 +60,29 @@ class TnPImplOnLeg:
         p1, a1 = self.find_probes(zcands1, good_events.TrigObj, self.pt, self.filterbit)
         p2, a2 = self.find_probes(zcands2, good_events.TrigObj, self.pt, self.filterbit)
 
-        return p1, a1, p2, a2
+        p = dak.concatenate([p1, p2])
+        a = dak.concatenate([a1, a2])
+
+        passing_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": p.pt,
+                    "eta": p.eta,
+                    "phi": p.phi,
+                }
+            )
+        )
+        all_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": a.pt,
+                    "eta": a.eta,
+                    "phi": a.phi,
+                }
+            )
+        )
+
+        return passing_probes, all_probes
 
     def apply_lumimasking(self, events, goldenjson):
         lumimask = LumiMask(goldenjson)

--- a/src/egamma_tnp/triggers/elept1_elept2_caloidl_trackidl_isovl.py
+++ b/src/egamma_tnp/triggers/elept1_elept2_caloidl_trackidl_isovl.py
@@ -60,7 +60,29 @@ class TnPImplOnLeg:
         p1, a1 = self.find_probes(zcands1, good_events.TrigObj, self.pt, self.filterbit)
         p2, a2 = self.find_probes(zcands2, good_events.TrigObj, self.pt, self.filterbit)
 
-        return p1, a1, p2, a2
+        p = dak.concatenate([p1, p2])
+        a = dak.concatenate([a1, a2])
+
+        passing_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": p.pt,
+                    "eta": p.eta,
+                    "phi": p.phi,
+                }
+            )
+        )
+        all_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": a.pt,
+                    "eta": a.eta,
+                    "phi": a.phi,
+                }
+            )
+        )
+
+        return passing_probes, all_probes
 
     def apply_lumimasking(self, events, goldenjson):
         lumimask = LumiMask(goldenjson)

--- a/src/egamma_tnp/triggers/elept_caloidvt_gsftrkidt.py
+++ b/src/egamma_tnp/triggers/elept_caloidvt_gsftrkidt.py
@@ -60,7 +60,29 @@ class TnPImpl:
         p1, a1 = self.find_probes(zcands1, good_events.TrigObj, self.pt, self.filterbit)
         p2, a2 = self.find_probes(zcands2, good_events.TrigObj, self.pt, self.filterbit)
 
-        return p1, a1, p2, a2
+        p = dak.concatenate([p1, p2])
+        a = dak.concatenate([a1, a2])
+
+        passing_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": p.pt,
+                    "eta": p.eta,
+                    "phi": p.phi,
+                }
+            )
+        )
+        all_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": a.pt,
+                    "eta": a.eta,
+                    "phi": a.phi,
+                }
+            )
+        )
+
+        return passing_probes, all_probes
 
     def apply_lumimasking(self, events, goldenjson):
         lumimask = LumiMask(goldenjson)

--- a/src/egamma_tnp/triggers/elept_wptight_gsf.py
+++ b/src/egamma_tnp/triggers/elept_wptight_gsf.py
@@ -60,7 +60,29 @@ class TnPImpl:
         p1, a1 = self.find_probes(zcands1, good_events.TrigObj, self.pt, self.filterbit)
         p2, a2 = self.find_probes(zcands2, good_events.TrigObj, self.pt, self.filterbit)
 
-        return p1, a1, p2, a2
+        p = dak.concatenate([p1, p2])
+        a = dak.concatenate([a1, a2])
+
+        passing_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": p.pt,
+                    "eta": p.eta,
+                    "phi": p.phi,
+                }
+            )
+        )
+        all_probes = dak.flatten(
+            dak.zip(
+                {
+                    "pt": a.pt,
+                    "eta": a.eta,
+                    "phi": a.phi,
+                }
+            )
+        )
+
+        return passing_probes, all_probes
 
     def apply_lumimasking(self, events, goldenjson):
         lumimask = LumiMask(goldenjson)

--- a/src/egamma_tnp/triggers/ntuple_efficiency.py
+++ b/src/egamma_tnp/triggers/ntuple_efficiency.py
@@ -15,7 +15,7 @@ class TagNProbeFromNTuples:
         trigger_pt=None,
         goldenjson=None,
         extra_filter=None,
-        extra_filter_args={},
+        extra_filter_args=None,
     ):
         """Tag and Probe efficiency from E/Gamma NTuples
 
@@ -83,13 +83,15 @@ class TagNProbeFromNTuples:
         -------
             A tuple of the form (arrays, report) if `allow_read_errors_with_report` is True, otherwise just arrays.
             arrays :a tuple of dask awkward zip items of the form (passing_probes, all_probes).
-            Each of the zip items has the following fields:
-                pt: dask_awkward.Array
-                    The Pt array of the probes.
-                eta: dask_awkward.array
-                    The Eta array of the probes.
-                phi: dask_awkward.array
-                    The Phi array of the probes.
+                Each of the zip items has the following fields:
+                    pt: dask_awkward.Array
+                        The Pt array of the probes.
+                    eta: dask_awkward.array
+                        The Eta array of the probes.
+                    phi: dask_awkward.array
+                        The Phi array of the probes.
+            report: dict of awkward arrays of the same form as fileset.
+                For each dataset an awkward array that contains information about the file access is present.
         """
         if uproot_options is None:
             uproot_options = {}
@@ -171,17 +173,12 @@ class TagNProbeFromNTuples:
         -------
             A tuple of the form (histograms, report) if `allow_read_errors_with_report` is True, otherwise just histograms.
             histograms : dict of dicts of the same form as fileset where for each dataset the following dictionary is present:
-                A dictionary of the form `{"name": [hpt_pass, hpt_all, heta_pass, heta_all, hphi_pass, hphi_all], ...}`
-                Where each `"name"` is the name of each eta region defined by the user.
-                `hpt_pass` is a hist.Hist or hist.dask.Hist histogram of the Pt histogram of the passing probes.
-                `hpt_all` is a hist.Hist or hist.dask.Hist histogram of the Pt histogram of all probes.
-                `heta_pass` is a hist.Hist or hist.dask.Hist histogram of the Eta histogram of the passing probes.
-                `heta_all` is a hist.Hist or hist.dask.Hist histogram of the Eta histogram of all probes.
-                `hphi_pass` is a hist.Hist or hist.dask.Hist histogram of the Phi histogram of the passing probes.
-                `hphi_all` is a hist.Hist or hist.dask.Hist histogram of the Phi histogram of all probes.
+                A dictionary of the form `{"var": {"name": {"passing": passing_probes, "all": all_probes}, ...}, ...}`
+                where `"var"` can be `"pt"`, `"eta"`, or `"phi"`.
+                Each `"name"` is the name of eta region specified by the user and `passing_probes` and `all_probes` are `hist.dask.Hist` objects.
+                These are the histograms of the passing and all probes respectively.
             report: dict of awkward arrays of the same form as fileset.
                 For each dataset an awkward array that contains information about the file access is present.
-
         """
         data_manipulation = partial(
             self._make_tnp_histograms,

--- a/src/egamma_tnp/utils/__init__.py
+++ b/src/egamma_tnp/utils/__init__.py
@@ -1,10 +1,10 @@
 from egamma_tnp.utils.dataset import redirect_files
-from egamma_tnp.utils.histogramming import fill_eager_histograms, get_ratio_histogram
+from egamma_tnp.utils.histogramming import fill_tnp_histograms, get_ratio_histogram
 from egamma_tnp.utils.misc import delta_r_SC
 
 __all__ = (
     "redirect_files",
-    "fill_eager_histograms",
+    "fill_tnp_histograms",
     "get_ratio_histogram",
     "delta_r_SC",
 )

--- a/src/egamma_tnp/utils/histogramming.py
+++ b/src/egamma_tnp/utils/histogramming.py
@@ -30,25 +30,19 @@ def get_ratio_histogram(passing_probes, all_probes):
     return ratio, yerr
 
 
-def fill_eager_histograms(
-    res,
-    bins,
+def fill_tnp_histograms(
+    passing_probes,
+    all_probes,
     plateau_cut=None,
     eta_regions_pt=None,
     eta_regions_eta=None,
     eta_regions_phi=None,
+    delayed=True,
 ):
-    """Fill eager Pt and Eta histograms of the passing and all probes.
+    """Get the Pt and Eta histograms of the passing and all probes.
 
     Parameters
     ----------
-        res : tuple
-            The output of Trigger.get_arrays() with compute=True for single electron triggers.
-            The output of Trigger.get_arrays()["leg1"] or Trigger.get_arrays()["leg2"] with compute=True for double electron triggers
-        bins: dict
-            The binning of the histograms.
-            Should have 3 keys "ptbins", "etabins", and "phibins".
-            Each key should have a list of bin edges for the Pt, Eta, and Phi histograms respectively.
         plateau_cut : int or float, optional
             The Pt threshold to use to ensure that we are on the efficiency plateau for eta and phi histograms.
             The default None, meaning that no extra cut is applied and the activation region is included in those histograms.
@@ -67,17 +61,30 @@ def fill_eager_histograms(
             where name is the name of the region and etamin and etamax are the absolute eta bounds.
             The Phi histograms will be split into those eta regions.
             The default is to use the entire |eta| < 2.5 region.
+        delayed : bool, optional
+            Whether the probes arrays are delayed (dask-awkward) or not.
+            The default is True.
 
     Returns
     -------
         histograms : dict
-            A dictionary of the form `{"var": {"name": {"passing": passing_probes, "all": all_probes}, ...}, ...}`
-            Where `"var"` can be `"pt"`, `"eta"`, or `"phi"`.
-            Each `"name"` is the name of eta region specified by the user and `passing_probes` and `all_probes` are `hist.Hist` objects.
-            The are the histograms of the passing and all probes respectively.
+            A dictionary of the form `{"name": [hpt_pass, hpt_all, heta_pass, heta_all, hphi_pass, hphi_all], ...}`
+            Where each `"name"` is the name of each eta region defined by the user.
+            `hpt_pass` is a hist.Hist or hist.dask.Hist histogram of the Pt histogram of the passing probes.
+            `hpt_all` is a hist.Hist or hist.dask.Hist histogram of the Pt histogram of all probes.
+            `heta_pass` is a hist.Hist or hist.dask.Hist histogram of the Eta histogram of the passing probes.
+            `heta_all` is a hist.Hist or hist.dask.Hist histogram of the Eta histogram of all probes.
+            `hphi_pass` is a hist.Hist or hist.dask.Hist histogram of the Phi histogram of the passing probes.
+            `hphi_all` is a hist.Hist or hist.dask.Hist histogram of the Phi histogram of all probes.
     """
     import hist
-    from hist import Hist
+
+    if delayed:
+        from hist.dask import Hist
+    else:
+        from hist import Hist
+
+    import egamma_tnp
 
     if plateau_cut is None:
         plateau_cut = 0
@@ -91,73 +98,47 @@ def fill_eager_histograms(
     if eta_regions_phi is None:
         eta_regions_phi = {"entire": [0.0, 2.5]}
 
-    ptbins = bins["ptbins"]
-    etabins = bins["etabins"]
-    phibins = bins["phibins"]
+    ptbins = egamma_tnp.config.get("ptbins")
+    etabins = egamma_tnp.config.get("etabins")
+    phibins = egamma_tnp.config.get("phibins")
 
-    (
-        pt_pass1,
-        pt_pass2,
-        pt_all1,
-        pt_all2,
-        eta_pass1,
-        eta_pass2,
-        eta_all1,
-        eta_all2,
-        phi_pass1,
-        phi_pass2,
-        phi_all1,
-        phi_all2,
-    ) = res
+    pt_pass = passing_probes.pt
+    pt_all = all_probes.pt
+    eta_pass = passing_probes.eta
+    eta_all = all_probes.eta
+    phi_pass = passing_probes.phi
+    phi_all = all_probes.phi
 
     histograms = {}
     histograms["pt"] = {}
     histograms["eta"] = {}
     histograms["phi"] = {}
 
-    plateau_mask_pass1 = pt_pass1 > plateau_cut
-    plateau_mask_pass2 = pt_pass2 > plateau_cut
-    plateau_mask_all1 = pt_all1 > plateau_cut
-    plateau_mask_all2 = pt_all2 > plateau_cut
+    plateau_mask_pass = pt_pass > plateau_cut
+    plateau_mask_all = pt_all > plateau_cut
 
     for name_pt, region_pt in eta_regions_pt.items():
-        eta_mask_pt_pass1 = (abs(eta_pass1) > region_pt[0]) & (
-            abs(eta_pass1) < region_pt[1]
+        eta_mask_pt_pass = (abs(eta_pass) > region_pt[0]) & (
+            abs(eta_pass) < region_pt[1]
         )
-        eta_mask_pt_pass2 = (abs(eta_pass2) > region_pt[0]) & (
-            abs(eta_pass2) < region_pt[1]
-        )
-        eta_mask_pt_all1 = (abs(eta_all1) > region_pt[0]) & (
-            abs(eta_all1) < region_pt[1]
-        )
-        eta_mask_pt_all2 = (abs(eta_all2) > region_pt[0]) & (
-            abs(eta_all2) < region_pt[1]
-        )
+        eta_mask_pt_all = (abs(eta_all) > region_pt[0]) & (abs(eta_all) < region_pt[1])
         hpt_pass = Hist(
             hist.axis.Variable(ptbins, name=f"hpt_{name_pt}", label="Pt [GeV]")
         )
         hpt_all = Hist(
             hist.axis.Variable(ptbins, name=f"hpt_{name_pt}", label="Pt [GeV]")
         )
-        hpt_pass.fill(pt_pass1[eta_mask_pt_pass1])
-        hpt_pass.fill(pt_pass2[eta_mask_pt_pass2])
-        hpt_all.fill(pt_all1[eta_mask_pt_all1])
-        hpt_all.fill(pt_all2[eta_mask_pt_all2])
+        hpt_pass.fill(pt_pass[eta_mask_pt_pass])
+        hpt_all.fill(pt_all[eta_mask_pt_all])
 
         histograms["pt"][name_pt] = {"passing": hpt_pass, "all": hpt_all}
 
     for name_eta, region_eta in eta_regions_eta.items():
-        eta_mask_eta_pass1 = (abs(eta_pass1) > region_eta[0]) & (
-            abs(eta_pass1) < region_eta[1]
+        eta_mask_eta_pass = (abs(eta_pass) > region_eta[0]) & (
+            abs(eta_pass) < region_eta[1]
         )
-        eta_mask_eta_pass2 = (abs(eta_pass2) > region_eta[0]) & (
-            abs(eta_pass2) < region_eta[1]
-        )
-        eta_mask_eta_all1 = (abs(eta_all1) > region_eta[0]) & (
-            abs(eta_all1) < region_eta[1]
-        )
-        eta_mask_eta_all2 = (abs(eta_all2) > region_eta[0]) & (
-            abs(eta_all2) < region_eta[1]
+        eta_mask_eta_all = (abs(eta_all) > region_eta[0]) & (
+            abs(eta_all) < region_eta[1]
         )
         heta_pass = Hist(
             hist.axis.Variable(etabins, name=f"heta_{name_eta}", label="eta")
@@ -165,25 +146,17 @@ def fill_eager_histograms(
         heta_all = Hist(
             hist.axis.Variable(etabins, name=f"heta_{name_eta}", label="eta")
         )
-        heta_pass.fill(eta_pass1[plateau_mask_pass1 & eta_mask_eta_pass1])
-        heta_pass.fill(eta_pass2[plateau_mask_pass2 & eta_mask_eta_pass2])
-        heta_all.fill(eta_all1[plateau_mask_all1 & eta_mask_eta_all1])
-        heta_all.fill(eta_all2[plateau_mask_all2 & eta_mask_eta_all2])
+        heta_pass.fill(eta_pass[plateau_mask_pass & eta_mask_eta_pass])
+        heta_all.fill(eta_all[plateau_mask_all & eta_mask_eta_all])
 
         histograms["eta"][name_eta] = {"passing": heta_pass, "all": heta_all}
 
     for name_phi, region_phi in eta_regions_phi.items():
-        eta_mask_phi_pass1 = (abs(eta_pass1) > region_phi[0]) & (
-            abs(eta_pass1) < region_phi[1]
+        eta_mask_phi_pass = (abs(eta_pass) > region_phi[0]) & (
+            abs(eta_pass) < region_phi[1]
         )
-        eta_mask_phi_pass2 = (abs(eta_pass2) > region_phi[0]) & (
-            abs(eta_pass2) < region_phi[1]
-        )
-        eta_mask_phi_all1 = (abs(eta_all1) > region_phi[0]) & (
-            abs(eta_all1) < region_phi[1]
-        )
-        eta_mask_phi_all2 = (abs(eta_all2) > region_phi[0]) & (
-            abs(eta_all2) < region_phi[1]
+        eta_mask_phi_all = (abs(eta_all) > region_phi[0]) & (
+            abs(eta_all) < region_phi[1]
         )
         hphi_pass = Hist(
             hist.axis.Variable(phibins, name=f"hphi_{name_phi}", label="phi")
@@ -191,10 +164,8 @@ def fill_eager_histograms(
         hphi_all = Hist(
             hist.axis.Variable(phibins, name=f"hphi_{name_phi}", label="phi")
         )
-        hphi_pass.fill(phi_pass1[plateau_mask_pass1 & eta_mask_phi_pass1])
-        hphi_pass.fill(phi_pass2[plateau_mask_pass2 & eta_mask_phi_pass2])
-        hphi_all.fill(phi_all1[plateau_mask_all1 & eta_mask_phi_all1])
-        hphi_all.fill(phi_all2[plateau_mask_all2 & eta_mask_phi_all2])
+        hphi_pass.fill(phi_pass[plateau_mask_pass & eta_mask_phi_pass])
+        hphi_all.fill(phi_all[plateau_mask_all & eta_mask_phi_all])
 
         histograms["phi"][name_phi] = {"passing": hphi_pass, "all": hphi_all}
 

--- a/src/egamma_tnp/utils/histogramming.py
+++ b/src/egamma_tnp/utils/histogramming.py
@@ -68,14 +68,11 @@ def fill_tnp_histograms(
     Returns
     -------
         histograms : dict
-            A dictionary of the form `{"name": [hpt_pass, hpt_all, heta_pass, heta_all, hphi_pass, hphi_all], ...}`
-            Where each `"name"` is the name of each eta region defined by the user.
-            `hpt_pass` is a hist.Hist or hist.dask.Hist histogram of the Pt histogram of the passing probes.
-            `hpt_all` is a hist.Hist or hist.dask.Hist histogram of the Pt histogram of all probes.
-            `heta_pass` is a hist.Hist or hist.dask.Hist histogram of the Eta histogram of the passing probes.
-            `heta_all` is a hist.Hist or hist.dask.Hist histogram of the Eta histogram of all probes.
-            `hphi_pass` is a hist.Hist or hist.dask.Hist histogram of the Phi histogram of the passing probes.
-            `hphi_all` is a hist.Hist or hist.dask.Hist histogram of the Phi histogram of all probes.
+            A dictionary of the form `{"var": {"name": {"passing": passing_probes, "all": all_probes}, ...}, ...}`
+            where `"var"` can be `"pt"`, `"eta"`, or `"phi"`.
+            Each `"name"` is the name of eta region specified by the user.
+            `passing_probes` and `all_probes` are `hist.Hist` or `hist.dask.Hist` objects.
+            These are the histograms of the passing and all probes respectively.
     """
     import hist
 
@@ -181,10 +178,9 @@ def save_hists(path, res):
             The path to the ROOT file.
         res : dict
             A histogram dictionary of the form {"var": {"region": {"passing": hist.Hist, "all": hist.Hist}, ...}, ...}
-
     """
     with uproot.recreate(path) as f:
         for var, region_dict in res.items():
             for region_name, hists in region_dict.items():
-                for i, (histname, h) in enumerate(hists.items()):
+                for histname, h in hists.items():
                     f[f"{var}/{region_name}/{histname}"] = h

--- a/tests/test_doubleelept_caloidl_mw_nanoaod.py
+++ b/tests/test_doubleelept_caloidl_mw_nanoaod.py
@@ -330,10 +330,16 @@ def test_local_compute(do_preprocess, allow_read_errors_with_report):
         histograms_leg2 = res_leg2["sample"]
         histograms_both = res_both["sample"]
 
-    for arr1, arr2 in zip(arrays_leg1["leg1"], arrays_both["leg1"]):
-        assert np.all(arr1 == arr2)
-    for arr1, arr2 in zip(arrays_leg2["leg2"], arrays_both["leg2"]):
-        assert np.all(arr1 == arr2)
+    arrays_pass_leg1, arrays_all_leg1 = arrays_leg1["leg1"]
+    arrays_pass_leg2, arrays_all_leg2 = arrays_leg2["leg2"]
+    arrays_pass_both_leg1, arrays_all_both_leg1 = arrays_both["leg1"]
+    arrays_pass_both_leg2, arrays_all_both_leg2 = arrays_both["leg2"]
+
+    for field in ["pt", "eta", "phi"]:
+        assert np.all(arrays_pass_leg1[field] == arrays_pass_both_leg1[field])
+        assert np.all(arrays_pass_leg2[field] == arrays_pass_both_leg2[field])
+        assert np.all(arrays_all_leg1[field] == arrays_all_both_leg1[field])
+        assert np.all(arrays_all_leg2[field] == arrays_all_both_leg2[field])
 
     if not preprocess:
         assert report_arrays_leg1.exception[1] == "FileNotFoundError"
@@ -614,10 +620,16 @@ def test_distributed_compute(do_preprocess, allow_read_errors_with_report):
             histograms_leg2 = res_leg2["sample"]
             histograms_both = res_both["sample"]
 
-        for arr1, arr2 in zip(arrays_leg1["leg1"], arrays_both["leg1"]):
-            assert np.all(arr1 == arr2)
-        for arr1, arr2 in zip(arrays_leg2["leg2"], arrays_both["leg2"]):
-            assert np.all(arr1 == arr2)
+        arrays_pass_leg1, arrays_all_leg1 = arrays_leg1["leg1"]
+        arrays_pass_leg2, arrays_all_leg2 = arrays_leg2["leg2"]
+        arrays_pass_both_leg1, arrays_all_both_leg1 = arrays_both["leg1"]
+        arrays_pass_both_leg2, arrays_all_both_leg2 = arrays_both["leg2"]
+
+        for field in ["pt", "eta", "phi"]:
+            assert np.all(arrays_pass_leg1[field] == arrays_pass_both_leg1[field])
+            assert np.all(arrays_pass_leg2[field] == arrays_pass_both_leg2[field])
+            assert np.all(arrays_all_leg1[field] == arrays_all_both_leg1[field])
+            assert np.all(arrays_all_leg2[field] == arrays_all_both_leg2[field])
 
         if not preprocess:
             assert report_arrays_leg1.exception[1] == "FileNotFoundError"

--- a/tests/test_elept1_elept2_caloidl_trackidl_isovl_nanoaod.py
+++ b/tests/test_elept1_elept2_caloidl_trackidl_isovl_nanoaod.py
@@ -332,10 +332,16 @@ def test_local_compute(do_preprocess, allow_read_errors_with_report):
         histograms_leg2 = res_leg2["sample"]
         histograms_both = res_both["sample"]
 
-    for arr1, arr2 in zip(arrays_leg1["leg1"], arrays_both["leg1"]):
-        assert np.all(arr1 == arr2)
-    for arr1, arr2 in zip(arrays_leg2["leg2"], arrays_both["leg2"]):
-        assert np.all(arr1 == arr2)
+    arrays_pass_leg1, arrays_all_leg1 = arrays_leg1["leg1"]
+    arrays_pass_leg2, arrays_all_leg2 = arrays_leg2["leg2"]
+    arrays_pass_both_leg1, arrays_all_both_leg1 = arrays_both["leg1"]
+    arrays_pass_both_leg2, arrays_all_both_leg2 = arrays_both["leg2"]
+
+    for field in ["pt", "eta", "phi"]:
+        assert np.all(arrays_pass_leg1[field] == arrays_pass_both_leg1[field])
+        assert np.all(arrays_pass_leg2[field] == arrays_pass_both_leg2[field])
+        assert np.all(arrays_all_leg1[field] == arrays_all_both_leg1[field])
+        assert np.all(arrays_all_leg2[field] == arrays_all_both_leg2[field])
 
     if not preprocess:
         assert report_arrays_leg1.exception[1] == "FileNotFoundError"
@@ -620,10 +626,16 @@ def test_distributed_compute(do_preprocess, allow_read_errors_with_report):
             histograms_leg2 = res_leg2["sample"]
             histograms_both = res_both["sample"]
 
-        for arr1, arr2 in zip(arrays_leg1["leg1"], arrays_both["leg1"]):
-            assert np.all(arr1 == arr2)
-        for arr1, arr2 in zip(arrays_leg2["leg2"], arrays_both["leg2"]):
-            assert np.all(arr1 == arr2)
+        arrays_pass_leg1, arrays_all_leg1 = arrays_leg1["leg1"]
+        arrays_pass_leg2, arrays_all_leg2 = arrays_leg2["leg2"]
+        arrays_pass_both_leg1, arrays_all_both_leg1 = arrays_both["leg1"]
+        arrays_pass_both_leg2, arrays_all_both_leg2 = arrays_both["leg2"]
+
+        for field in ["pt", "eta", "phi"]:
+            assert np.all(arrays_pass_leg1[field] == arrays_pass_both_leg1[field])
+            assert np.all(arrays_pass_leg2[field] == arrays_pass_both_leg2[field])
+            assert np.all(arrays_all_leg1[field] == arrays_all_both_leg1[field])
+            assert np.all(arrays_all_leg2[field] == arrays_all_both_leg2[field])
 
         if not preprocess:
             assert report_arrays_leg1.exception[1] == "FileNotFoundError"


### PR DESCRIPTION
This PR aims to update the histograming within this package and avoid filling dask histograms in two steps by making use of `dak.concatenate(..., axis=0)` now that it's functional. 
This should improve the readability of the code and also allow us to not repeat code in some places because now the histogramming from NTuples and from NanoAOD can be combined into one histogramming function.